### PR TITLE
fixing a bug that throws error when factoid plugin isn't loaded

### DIFF
--- a/vbot.js
+++ b/vbot.js
@@ -117,7 +117,7 @@ Bot.prototype.parse_message = function (channel, sender, text, message_type) {
             var params = possible_command[2] || '';
             this.commands[command].callback.call(this, context, params, command);
         }
-        else {
+        else if (typeof this.commands.factoid !== "undefined") {
             var factoid = message_matches[1];
             this.commands['factoid'].callback.call(this, context, factoid, 'factoid');
         }


### PR DESCRIPTION
NOTE: this is only a temporary fix for a larger issue. Factoids needs to be rewriten to not depend on code in the bot core, but instead to register and unregister commands inside of it's own context.